### PR TITLE
fix: missing mweb filter wo/ p2pv2

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -102,17 +102,17 @@ public:
           host = optarg;
           break;
         }
-        
+
         case 'm': {
           mbox = optarg;
           break;
         }
-        
+
         case 'n': {
           ns = optarg;
           break;
         }
-        
+
         case 't': {
           int n = strtol(optarg, NULL, 10);
           if (n > 0 && n < 1000) nThreads = n;
@@ -215,7 +215,9 @@ public:
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_COMPACT_FILTERS | NODE_MWEB | NODE_MWEB_LIGHT_CLIENT); //0x1800049
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_P2P_V2); // x809
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_P2P_V2 | NODE_COMPACT_FILTERS); //x849
+        filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_COMPACT_FILTERS | NODE_MWEB); // 0x1000049
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_P2P_V2 | NODE_COMPACT_FILTERS | NODE_MWEB); //0x1000849
+        filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_COMPACT_FILTERS | NODE_MWEB | NODE_MWEB_LIGHT_CLIENT); //0x1800049
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_P2P_V2 | NODE_COMPACT_FILTERS | NODE_MWEB | NODE_MWEB_LIGHT_CLIENT); //0x1800849
         filter_whitelist.insert(NODE_NETWORK | NODE_WITNESS | NODE_BLOOM); // xd
         filter_whitelist.insert(NODE_NETWORK_LIMITED); // x400


### PR DESCRIPTION
P2Pv2 is not generally available in Litecoin Core, and we were missing frequently requested service bits (`0x1800049` is requested by Nexus Wallet, mwebd and ltcsuite).